### PR TITLE
Add newsletter and wiki archives

### DIFF
--- a/app/newsletter/page.tsx
+++ b/app/newsletter/page.tsx
@@ -6,7 +6,7 @@ const newsletterYears: ArchiveYear[] = [
     year: 'AY25/26',
     editions: [
       {
-        label: 'ISSUE 2 - SEMESTER 2',
+        label: 'Issue 2 - Semester 2',
         href: 'https://ogmmddvrmieazwmy.public.blob.vercel-storage.com/newsletters/ay25-26/semester-2.pdf',
       },
     ],

--- a/app/newsletter/page.tsx
+++ b/app/newsletter/page.tsx
@@ -14,13 +14,20 @@ const newsletterYears: ArchiveYear[] = [
   {
     year: 'AY24/25',
     editions: [
-      { label: 'SEMESTER 2', href: 'https://t.me/NUSChannel/6245' },
-      { label: 'SEMESTER 1', href: 'https://t.me/NUSChannel/6005' },
+      {
+        label: 'View edition',
+        href: 'https://sites.google.com/view/nusc-wiki-2425/home',
+      },
     ],
   },
   {
     year: 'AY22/23',
-    editions: [{ label: 'VIEW EDITION', href: 'https://t.me/NUSChannel/5207' }],
+    editions: [
+      {
+        label: 'The NUSC Minute',
+        href: 'https://ogmmddvrmieazwmy.public.blob.vercel-storage.com/newsletters/ay22-23/the-nusc-minute.pdf',
+      },
+    ],
   },
 ];
 

--- a/app/newsletter/page.tsx
+++ b/app/newsletter/page.tsx
@@ -12,15 +12,6 @@ const newsletterYears: ArchiveYear[] = [
     ],
   },
   {
-    year: 'AY24/25',
-    editions: [
-      {
-        label: 'View edition',
-        href: 'https://sites.google.com/view/nusc-wiki-2425/home',
-      },
-    ],
-  },
-  {
     year: 'AY22/23',
     editions: [
       {

--- a/app/newsletter/page.tsx
+++ b/app/newsletter/page.tsx
@@ -4,7 +4,12 @@ const newsletterYears: ArchiveYear[] = [
   { year: 'AY26/27' },
   {
     year: 'AY25/26',
-    editions: [{ label: 'SEMESTER 2', href: 'https://t.me/NUSChannel/6691' }],
+    editions: [
+      {
+        label: 'ISSUE 2 - SEMESTER 2',
+        href: 'https://ogmmddvrmieazwmy.public.blob.vercel-storage.com/newsletters/ay25-26/semester-2.pdf',
+      },
+    ],
   },
   {
     year: 'AY24/25',

--- a/app/newsletter/page.tsx
+++ b/app/newsletter/page.tsx
@@ -1,0 +1,30 @@
+import ArchivePage, { type ArchiveYear } from '@/components/ArchivePage';
+
+const newsletterYears: ArchiveYear[] = [
+  { year: 'AY26/27' },
+  {
+    year: 'AY25/26',
+    editions: [{ label: 'SEMESTER 2', href: 'https://t.me/NUSChannel/6691' }],
+  },
+  {
+    year: 'AY24/25',
+    editions: [
+      { label: 'SEMESTER 2', href: 'https://t.me/NUSChannel/6245' },
+      { label: 'SEMESTER 1', href: 'https://t.me/NUSChannel/6005' },
+    ],
+  },
+  {
+    year: 'AY22/23',
+    editions: [{ label: 'VIEW EDITION', href: 'https://t.me/NUSChannel/5207' }],
+  },
+];
+
+export default function NewsletterPage() {
+  return (
+    <ArchivePage
+      archiveName='Newsletter Archive'
+      description='Browse past NUS College Club newsletters and keep up with the stories, updates, and moments that shaped Student Life.'
+      years={newsletterYears}
+    />
+  );
+}

--- a/app/newsletter/page.tsx
+++ b/app/newsletter/page.tsx
@@ -1,33 +1,6 @@
-import ArchivePage, { type ArchiveYear } from '@/components/ArchivePage';
-
-const newsletterYears: ArchiveYear[] = [
-  { year: 'AY26/27' },
-  {
-    year: 'AY25/26',
-    editions: [
-      {
-        label: 'Issue 2 - Semester 2',
-        href: 'https://ogmmddvrmieazwmy.public.blob.vercel-storage.com/newsletters/ay25-26/semester-2.pdf',
-      },
-    ],
-  },
-  {
-    year: 'AY22/23',
-    editions: [
-      {
-        label: 'The NUSC Minute',
-        href: 'https://ogmmddvrmieazwmy.public.blob.vercel-storage.com/newsletters/ay22-23/the-nusc-minute.pdf',
-      },
-    ],
-  },
-];
+import ArchivePage from '@/components/ArchivePage';
+import { newsletterArchive } from '@/lib/archive';
 
 export default function NewsletterPage() {
-  return (
-    <ArchivePage
-      archiveName='Newsletter Archive'
-      description='Browse past NUS College Club newsletters and keep up with the stories, updates, and moments that shaped Student Life.'
-      years={newsletterYears}
-    />
-  );
+  return <ArchivePage archive={newsletterArchive} />;
 }

--- a/app/wiki/page.tsx
+++ b/app/wiki/page.tsx
@@ -1,0 +1,42 @@
+import ArchivePage, { type ArchiveYear } from '@/components/ArchivePage';
+
+const wikiYears: ArchiveYear[] = [
+  { year: 'AY25/26' },
+  {
+    year: 'AY24/25',
+    editions: [
+      {
+        label: 'VIEW WIKI',
+        href: 'https://sites.google.com/view/nusc-wiki-2425/home',
+      },
+    ],
+  },
+  {
+    year: 'AY23/24',
+    editions: [
+      {
+        label: 'VIEW WIKI',
+        href: 'https://nusc-wiki.gitbook.io/nusc-wiki-23-24/',
+      },
+    ],
+  },
+  {
+    year: 'AY22/23',
+    editions: [
+      {
+        label: 'VIEW WIKI',
+        href: 'https://nusc-wiki.gitbook.io/nusc-wiki-22/',
+      },
+    ],
+  },
+];
+
+export default function WikiPage() {
+  return (
+    <ArchivePage
+      archiveName='Wiki Archive'
+      description='Explore the NUS College Club wiki archives for practical guides, community knowledge, and resources collected by students.'
+      years={wikiYears}
+    />
+  );
+}

--- a/app/wiki/page.tsx
+++ b/app/wiki/page.tsx
@@ -1,42 +1,6 @@
-import ArchivePage, { type ArchiveYear } from '@/components/ArchivePage';
-
-const wikiYears: ArchiveYear[] = [
-  { year: 'AY25/26' },
-  {
-    year: 'AY24/25',
-    editions: [
-      {
-        label: 'VIEW WIKI',
-        href: 'https://sites.google.com/view/nusc-wiki-2425/home',
-      },
-    ],
-  },
-  {
-    year: 'AY23/24',
-    editions: [
-      {
-        label: 'VIEW WIKI',
-        href: 'https://nusc-wiki.gitbook.io/nusc-wiki-23-24/',
-      },
-    ],
-  },
-  {
-    year: 'AY22/23',
-    editions: [
-      {
-        label: 'VIEW WIKI',
-        href: 'https://nusc-wiki.gitbook.io/nusc-wiki-22/',
-      },
-    ],
-  },
-];
+import ArchivePage from '@/components/ArchivePage';
+import { wikiArchive } from '@/lib/archive';
 
 export default function WikiPage() {
-  return (
-    <ArchivePage
-      archiveName='Wiki Archive'
-      description='Explore the NUS College Club wiki archives for practical guides, community knowledge, and resources collected by students.'
-      years={wikiYears}
-    />
-  );
+  return <ArchivePage archive={wikiArchive} />;
 }

--- a/components/ArchivePage.tsx
+++ b/components/ArchivePage.tsx
@@ -1,0 +1,96 @@
+import { ExternalLinkIcon } from 'lucide-react';
+import Image from 'next/image';
+import Link from 'next/link';
+
+interface ArchiveEdition {
+  label: string;
+  href: string;
+}
+
+export interface ArchiveYear {
+  year: string;
+  editions?: ArchiveEdition[];
+}
+
+interface ArchivePageProps {
+  archiveName: string;
+  description: string;
+  years: ArchiveYear[];
+}
+
+export default function ArchivePage({
+  archiveName,
+  description,
+  years,
+}: ArchivePageProps) {
+  const anchorFor = (year: string) =>
+    year.toLowerCase().replaceAll(/[^a-z0-9]+/g, '-');
+
+  return (
+    <>
+      <section className='relative h-80 w-full overflow-hidden md:h-104'>
+        <Image
+          src='/images/hero.jpg'
+          alt='Students performing at a NUS College event'
+          fill
+          sizes='100vw'
+          className='object-cover'
+          priority
+        />
+        <div className='absolute inset-0 bg-linear-to-b from-[rgba(29,107,173,0)] to-[#0C2C47]' />
+        <div className='relative z-10 flex h-full items-end px-8 pb-12 md:px-16 md:pb-16'>
+          <h1 className='text-4xl font-bold text-white md:text-6xl'>
+            {archiveName}
+          </h1>
+        </div>
+      </section>
+
+      <section className='bg-white px-8 py-14 md:px-16 md:py-20'>
+        <div className='mx-auto max-w-7xl'>
+          <p className='max-w-3xl text-lg leading-8 text-gray-600'>
+            {description}
+          </p>
+
+          <div className='mt-12 grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3'>
+            {years.map((year) => (
+              <article
+                key={year.year}
+                id={anchorFor(year.year)}
+                className='flex min-h-56 scroll-mt-24 flex-col items-center justify-center bg-[#FFF4E5] p-8 text-center'
+              >
+                <h2 className='text-2xl font-bold text-[#0C2C47] uppercase'>
+                  {year.year}
+                </h2>
+                {year.editions ? (
+                  <ul className='mt-6 space-y-3'>
+                    {year.editions.map((edition) => (
+                      <li key={edition.href}>
+                        <Link
+                          href={edition.href}
+                          target='_blank'
+                          rel='noopener noreferrer'
+                          className='inline-flex items-center gap-2 font-semibold text-[#FF7D4E] underline decoration-2 underline-offset-4 hover:text-[#0C2C47] focus-visible:text-[#0C2C47]'
+                        >
+                          {edition.label}
+                          <ExternalLinkIcon
+                            className='h-4 w-4 shrink-0'
+                            aria-hidden='true'
+                          />
+                          <span className='sr-only'>(opens in a new tab)</span>
+                        </Link>
+                      </li>
+                    ))}
+                  </ul>
+                ) : (
+                  <p className='mt-6 font-semibold text-gray-500'>
+                    FORTHCOMING
+                  </p>
+                )}
+              </article>
+            ))}
+          </div>
+        </div>
+      </section>
+    </>
+  );
+}

--- a/components/ArchivePage.tsx
+++ b/components/ArchivePage.tsx
@@ -2,30 +2,13 @@ import { ExternalLinkIcon } from 'lucide-react';
 import Image from 'next/image';
 import Link from 'next/link';
 
-interface ArchiveEdition {
-  label: string;
-  href: string;
-}
-
-export interface ArchiveYear {
-  year: string;
-  editions?: ArchiveEdition[];
-}
-
-interface ArchivePageProps {
-  archiveName: string;
-  description: string;
-  years: ArchiveYear[];
-}
+import { anchorForArchiveYear, type ArchiveDefinition } from '@/lib/archive';
 
 export default function ArchivePage({
-  archiveName,
-  description,
-  years,
-}: ArchivePageProps) {
-  const anchorFor = (year: string) =>
-    year.toLowerCase().replaceAll(/[^a-z0-9]+/g, '-');
-
+  archive,
+}: {
+  archive: ArchiveDefinition;
+}) {
   return (
     <>
       <section className='relative h-80 w-full overflow-hidden md:h-104'>
@@ -40,7 +23,7 @@ export default function ArchivePage({
         <div className='absolute inset-0 bg-linear-to-b from-[rgba(29,107,173,0)] to-[#0C2C47]' />
         <div className='relative z-10 flex h-full items-end px-8 pb-12 md:px-16 md:pb-16'>
           <h1 className='text-4xl font-bold text-white md:text-6xl'>
-            {archiveName}
+            {archive.name}
           </h1>
         </div>
       </section>
@@ -48,14 +31,14 @@ export default function ArchivePage({
       <section className='bg-white px-8 py-14 md:px-16 md:py-20'>
         <div className='mx-auto max-w-7xl'>
           <p className='max-w-3xl text-lg leading-8 text-gray-600'>
-            {description}
+            {archive.description}
           </p>
 
           <div className='mt-12 grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3'>
-            {years.map((year) => (
+            {archive.years.map((year) => (
               <article
                 key={year.year}
-                id={anchorFor(year.year)}
+                id={anchorForArchiveYear(year.year)}
                 className='flex min-h-56 scroll-mt-24 flex-col items-center justify-center bg-[#FFF4E5] p-8 text-center'
               >
                 <h2 className='text-2xl font-bold text-[#0C2C47] uppercase'>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -33,8 +33,24 @@ import { useAuth } from '@/lib/hooks/useAuth';
 
 import CustomDropdown from './custom-dropdown';
 
+const newsletterArchiveItems = [
+  { label: 'AY26/27', href: '/newsletter#ay26-27' },
+  { label: 'AY25/26', href: '/newsletter#ay25-26' },
+  { label: 'AY24/25', href: '/newsletter#ay24-25' },
+  { label: 'AY22/23', href: '/newsletter#ay22-23' },
+];
+
+const wikiArchiveItems = [
+  { label: 'AY25/26', href: '/wiki#ay25-26' },
+  { label: 'AY24/25', href: '/wiki#ay24-25' },
+  { label: 'AY23/24', href: '/wiki#ay23-24' },
+  { label: 'AY22/23', href: '/wiki#ay22-23' },
+];
+
 export default function Header() {
   const [mobileSubmenuOpen, setMobileSubmenuOpen] = useState(true);
+  const [mobileNewsletterOpen, setMobileNewsletterOpen] = useState(false);
+  const [mobileWikiOpen, setMobileWikiOpen] = useState(false);
   const [adminSubmenuOpen, setAdminSubmenuOpen] = useState(true);
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
 
@@ -60,11 +76,15 @@ export default function Header() {
         <div className='lg:hidden'>
           <Sheet open={isSidebarOpen} onOpenChange={setIsSidebarOpen}>
             <SheetTrigger asChild>
-              <Button variant='ghost' size='icon'>
-                <MenuIcon className='h-6 w-6' />
+              <Button
+                variant='ghost'
+                size='icon'
+                aria-label='Open navigation menu'
+              >
+                <MenuIcon className='h-6 w-6' aria-hidden='true' />
               </Button>
             </SheetTrigger>
-            <SheetContent side='left'>
+            <SheetContent side='left' className='overflow-y-auto'>
               <SheetHeader>
                 <SheetTitle />
                 <SheetDescription className='sr-only'>
@@ -137,15 +157,94 @@ export default function Header() {
                     </NavigationMenuLink>
                   </NavigationMenuItem>
 
-                  <NavigationMenuItem>
-                    <NavigationMenuLink asChild>
+                  <NavigationMenuItem className='w-full'>
+                    <div className='flex items-center justify-between'>
                       <Link
-                        href='https://sites.google.com/view/nusc-wiki-2425/home'
-                        target='_blank'
+                        href='/newsletter'
+                        className='py-1'
+                        onClick={() => setIsSidebarOpen(false)}
                       >
                         NEWSLETTER
                       </Link>
-                    </NavigationMenuLink>
+                      <button
+                        type='button'
+                        className='p-2'
+                        onClick={() => setMobileNewsletterOpen((open) => !open)}
+                        aria-controls='mobile-newsletter-years'
+                        aria-expanded={mobileNewsletterOpen}
+                        aria-label='Toggle Newsletter years'
+                      >
+                        {mobileNewsletterOpen ? (
+                          <ChevronDownIcon className='h-4 w-4' />
+                        ) : (
+                          <ChevronRightIcon className='h-4 w-4' />
+                        )}
+                      </button>
+                    </div>
+                    {mobileNewsletterOpen && (
+                      <div
+                        id='mobile-newsletter-years'
+                        className='pl-4'
+                        role='region'
+                        aria-label='Newsletter years'
+                      >
+                        {newsletterArchiveItems.map((item) => (
+                          <Link
+                            key={item.href}
+                            href={item.href}
+                            className='block py-1 text-sm'
+                            onClick={() => setIsSidebarOpen(false)}
+                          >
+                            {item.label}
+                          </Link>
+                        ))}
+                      </div>
+                    )}
+                  </NavigationMenuItem>
+
+                  <NavigationMenuItem className='w-full'>
+                    <div className='flex items-center justify-between'>
+                      <Link
+                        href='/wiki'
+                        className='py-1'
+                        onClick={() => setIsSidebarOpen(false)}
+                      >
+                        WIKI
+                      </Link>
+                      <button
+                        type='button'
+                        className='p-2'
+                        onClick={() => setMobileWikiOpen((open) => !open)}
+                        aria-controls='mobile-wiki-years'
+                        aria-expanded={mobileWikiOpen}
+                        aria-label='Toggle Wiki years'
+                      >
+                        {mobileWikiOpen ? (
+                          <ChevronDownIcon className='h-4 w-4' />
+                        ) : (
+                          <ChevronRightIcon className='h-4 w-4' />
+                        )}
+                      </button>
+                    </div>
+                    {mobileWikiOpen && (
+                      <div
+                        id='mobile-wiki-years'
+                        className='pl-4'
+                        role='region'
+                        aria-label='Wiki years'
+                      >
+                        {wikiArchiveItems.map((item) => (
+                          <Link
+                            key={item.href}
+                            href={item.href}
+                            className='block py-1 text-sm'
+                            onClick={() => setIsSidebarOpen(false)}
+                          >
+                            {item.label}
+                          </Link>
+                        ))}
+                      </div>
+                    )}
                   </NavigationMenuItem>
 
                   {/* Admin menu for logged in users */}
@@ -232,17 +331,18 @@ export default function Header() {
               </NavigationMenuLink>
             </NavigationMenuItem>
             <NavigationMenuItem>
-              <NavigationMenuLink
-                className={navigationMenuTriggerStyle()}
-                asChild
-              >
-                <Link
-                  href='https://sites.google.com/view/nusc-wiki-2425/home'
-                  target='_blank'
-                >
-                  NEWSLETTER
-                </Link>
-              </NavigationMenuLink>
+              <CustomDropdown
+                label='NEWSLETTER'
+                href='/newsletter'
+                items={newsletterArchiveItems}
+              />
+            </NavigationMenuItem>
+            <NavigationMenuItem>
+              <CustomDropdown
+                label='WIKI'
+                href='/wiki'
+                items={wikiArchiveItems}
+              />
             </NavigationMenuItem>
 
             {/* Spacer pushes following items to the right */}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -29,34 +29,17 @@ import {
   SheetTitle,
   SheetTrigger,
 } from '@/components/ui/sheet';
+import {
+  getArchiveDropdownItems,
+  newsletterArchive,
+  wikiArchive,
+} from '@/lib/archive';
 import { useAuth } from '@/lib/hooks/useAuth';
 
 import CustomDropdown from './custom-dropdown';
 
-const newsletterArchiveItems = [
-  { label: 'AY26/27', href: '/newsletter' },
-  {
-    label: 'AY25/26',
-    href: 'https://ogmmddvrmieazwmy.public.blob.vercel-storage.com/newsletters/ay25-26/semester-2.pdf',
-  },
-  {
-    label: 'AY22/23',
-    href: 'https://ogmmddvrmieazwmy.public.blob.vercel-storage.com/newsletters/ay22-23/the-nusc-minute.pdf',
-  },
-];
-
-const wikiArchiveItems = [
-  { label: 'AY25/26', href: '/wiki' },
-  {
-    label: 'AY24/25',
-    href: 'https://sites.google.com/view/nusc-wiki-2425/home',
-  },
-  {
-    label: 'AY23/24',
-    href: 'https://nusc-wiki.gitbook.io/nusc-wiki-23-24/',
-  },
-  { label: 'AY22/23', href: 'https://nusc-wiki.gitbook.io/nusc-wiki-22/' },
-];
+const newsletterArchiveItems = getArchiveDropdownItems(newsletterArchive);
+const wikiArchiveItems = getArchiveDropdownItems(wikiArchive);
 
 export default function Header() {
   const [mobileSubmenuOpen, setMobileSubmenuOpen] = useState(true);
@@ -171,7 +154,7 @@ export default function Header() {
                   <NavigationMenuItem className='w-full'>
                     <div className='flex items-center justify-between'>
                       <Link
-                        href='/newsletter'
+                        href={newsletterArchive.href}
                         className='py-1'
                         onClick={() => setIsSidebarOpen(false)}
                       >
@@ -226,7 +209,7 @@ export default function Header() {
                   <NavigationMenuItem className='w-full'>
                     <div className='flex items-center justify-between'>
                       <Link
-                        href='/wiki'
+                        href={wikiArchive.href}
                         className='py-1'
                         onClick={() => setIsSidebarOpen(false)}
                       >
@@ -364,14 +347,14 @@ export default function Header() {
             <NavigationMenuItem>
               <CustomDropdown
                 label='NEWSLETTER'
-                href='/newsletter'
+                href={newsletterArchive.href}
                 items={newsletterArchiveItems}
               />
             </NavigationMenuItem>
             <NavigationMenuItem>
               <CustomDropdown
                 label='WIKI'
-                href='/wiki'
+                href={wikiArchive.href}
                 items={wikiArchiveItems}
               />
             </NavigationMenuItem>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -34,15 +34,28 @@ import { useAuth } from '@/lib/hooks/useAuth';
 import CustomDropdown from './custom-dropdown';
 
 const newsletterArchiveItems = [
-  { label: 'AY25/26', href: '/newsletter#ay25-26' },
-  { label: 'AY22/23', href: '/newsletter#ay22-23' },
+  { label: 'AY26/27', href: '/newsletter' },
+  {
+    label: 'AY25/26',
+    href: 'https://ogmmddvrmieazwmy.public.blob.vercel-storage.com/newsletters/ay25-26/semester-2.pdf',
+  },
+  {
+    label: 'AY22/23',
+    href: 'https://ogmmddvrmieazwmy.public.blob.vercel-storage.com/newsletters/ay22-23/the-nusc-minute.pdf',
+  },
 ];
 
 const wikiArchiveItems = [
-  { label: 'AY25/26', href: '/wiki#ay25-26' },
-  { label: 'AY24/25', href: '/wiki#ay24-25' },
-  { label: 'AY23/24', href: '/wiki#ay23-24' },
-  { label: 'AY22/23', href: '/wiki#ay22-23' },
+  { label: 'AY25/26', href: '/wiki' },
+  {
+    label: 'AY24/25',
+    href: 'https://sites.google.com/view/nusc-wiki-2425/home',
+  },
+  {
+    label: 'AY23/24',
+    href: 'https://nusc-wiki.gitbook.io/nusc-wiki-23-24/',
+  },
+  { label: 'AY22/23', href: 'https://nusc-wiki.gitbook.io/nusc-wiki-22/' },
 ];
 
 export default function Header() {
@@ -190,6 +203,16 @@ export default function Header() {
                           <Link
                             key={item.href}
                             href={item.href}
+                            target={
+                              item.href.startsWith('http')
+                                ? '_blank'
+                                : undefined
+                            }
+                            rel={
+                              item.href.startsWith('http')
+                                ? 'noopener noreferrer'
+                                : undefined
+                            }
                             className='block py-1 text-sm'
                             onClick={() => setIsSidebarOpen(false)}
                           >
@@ -235,6 +258,16 @@ export default function Header() {
                           <Link
                             key={item.href}
                             href={item.href}
+                            target={
+                              item.href.startsWith('http')
+                                ? '_blank'
+                                : undefined
+                            }
+                            rel={
+                              item.href.startsWith('http')
+                                ? 'noopener noreferrer'
+                                : undefined
+                            }
                             className='block py-1 text-sm'
                             onClick={() => setIsSidebarOpen(false)}
                           >

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -34,9 +34,7 @@ import { useAuth } from '@/lib/hooks/useAuth';
 import CustomDropdown from './custom-dropdown';
 
 const newsletterArchiveItems = [
-  { label: 'AY26/27', href: '/newsletter#ay26-27' },
   { label: 'AY25/26', href: '/newsletter#ay25-26' },
-  { label: 'AY24/25', href: '/newsletter#ay24-25' },
   { label: 'AY22/23', href: '/newsletter#ay22-23' },
 ];
 

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -29,22 +29,13 @@ import {
   SheetTitle,
   SheetTrigger,
 } from '@/components/ui/sheet';
-import {
-  getArchiveDropdownItems,
-  newsletterArchive,
-  wikiArchive,
-} from '@/lib/archive';
+import { newsletterArchive, wikiArchive } from '@/lib/archive';
 import { useAuth } from '@/lib/hooks/useAuth';
 
 import CustomDropdown from './custom-dropdown';
 
-const newsletterArchiveItems = getArchiveDropdownItems(newsletterArchive);
-const wikiArchiveItems = getArchiveDropdownItems(wikiArchive);
-
 export default function Header() {
   const [mobileSubmenuOpen, setMobileSubmenuOpen] = useState(true);
-  const [mobileNewsletterOpen, setMobileNewsletterOpen] = useState(false);
-  const [mobileWikiOpen, setMobileWikiOpen] = useState(false);
   const [adminSubmenuOpen, setAdminSubmenuOpen] = useState(true);
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
 
@@ -151,114 +142,26 @@ export default function Header() {
                     </NavigationMenuLink>
                   </NavigationMenuItem>
 
-                  <NavigationMenuItem className='w-full'>
-                    <div className='flex items-center justify-between'>
+                  <NavigationMenuItem>
+                    <NavigationMenuLink asChild>
                       <Link
                         href={newsletterArchive.href}
-                        className='py-1'
                         onClick={() => setIsSidebarOpen(false)}
                       >
                         NEWSLETTER
                       </Link>
-                      <button
-                        type='button'
-                        className='p-2'
-                        onClick={() => setMobileNewsletterOpen((open) => !open)}
-                        aria-controls='mobile-newsletter-years'
-                        aria-expanded={mobileNewsletterOpen}
-                        aria-label='Toggle Newsletter years'
-                      >
-                        {mobileNewsletterOpen ? (
-                          <ChevronDownIcon className='h-4 w-4' />
-                        ) : (
-                          <ChevronRightIcon className='h-4 w-4' />
-                        )}
-                      </button>
-                    </div>
-                    {mobileNewsletterOpen && (
-                      <div
-                        id='mobile-newsletter-years'
-                        className='pl-4'
-                        role='region'
-                        aria-label='Newsletter years'
-                      >
-                        {newsletterArchiveItems.map((item) => (
-                          <Link
-                            key={item.href}
-                            href={item.href}
-                            target={
-                              item.href.startsWith('http')
-                                ? '_blank'
-                                : undefined
-                            }
-                            rel={
-                              item.href.startsWith('http')
-                                ? 'noopener noreferrer'
-                                : undefined
-                            }
-                            className='block py-1 text-sm'
-                            onClick={() => setIsSidebarOpen(false)}
-                          >
-                            {item.label}
-                          </Link>
-                        ))}
-                      </div>
-                    )}
+                    </NavigationMenuLink>
                   </NavigationMenuItem>
 
-                  <NavigationMenuItem className='w-full'>
-                    <div className='flex items-center justify-between'>
+                  <NavigationMenuItem>
+                    <NavigationMenuLink asChild>
                       <Link
                         href={wikiArchive.href}
-                        className='py-1'
                         onClick={() => setIsSidebarOpen(false)}
                       >
                         WIKI
                       </Link>
-                      <button
-                        type='button'
-                        className='p-2'
-                        onClick={() => setMobileWikiOpen((open) => !open)}
-                        aria-controls='mobile-wiki-years'
-                        aria-expanded={mobileWikiOpen}
-                        aria-label='Toggle Wiki years'
-                      >
-                        {mobileWikiOpen ? (
-                          <ChevronDownIcon className='h-4 w-4' />
-                        ) : (
-                          <ChevronRightIcon className='h-4 w-4' />
-                        )}
-                      </button>
-                    </div>
-                    {mobileWikiOpen && (
-                      <div
-                        id='mobile-wiki-years'
-                        className='pl-4'
-                        role='region'
-                        aria-label='Wiki years'
-                      >
-                        {wikiArchiveItems.map((item) => (
-                          <Link
-                            key={item.href}
-                            href={item.href}
-                            target={
-                              item.href.startsWith('http')
-                                ? '_blank'
-                                : undefined
-                            }
-                            rel={
-                              item.href.startsWith('http')
-                                ? 'noopener noreferrer'
-                                : undefined
-                            }
-                            className='block py-1 text-sm'
-                            onClick={() => setIsSidebarOpen(false)}
-                          >
-                            {item.label}
-                          </Link>
-                        ))}
-                      </div>
-                    )}
+                    </NavigationMenuLink>
                   </NavigationMenuItem>
 
                   {/* Admin menu for logged in users */}
@@ -345,18 +248,20 @@ export default function Header() {
               </NavigationMenuLink>
             </NavigationMenuItem>
             <NavigationMenuItem>
-              <CustomDropdown
-                label='NEWSLETTER'
-                href={newsletterArchive.href}
-                items={newsletterArchiveItems}
-              />
+              <NavigationMenuLink
+                className={navigationMenuTriggerStyle()}
+                asChild
+              >
+                <Link href={newsletterArchive.href}>NEWSLETTER</Link>
+              </NavigationMenuLink>
             </NavigationMenuItem>
             <NavigationMenuItem>
-              <CustomDropdown
-                label='WIKI'
-                href={wikiArchive.href}
-                items={wikiArchiveItems}
-              />
+              <NavigationMenuLink
+                className={navigationMenuTriggerStyle()}
+                asChild
+              >
+                <Link href={wikiArchive.href}>WIKI</Link>
+              </NavigationMenuLink>
             </NavigationMenuItem>
 
             {/* Spacer pushes following items to the right */}

--- a/components/custom-dropdown.tsx
+++ b/components/custom-dropdown.tsx
@@ -223,9 +223,9 @@ const CustomDropdown: React.FC<CustomDropdownProps> = ({
           role='menu'
           onKeyDown={handleMenuKeyDown}
         >
-          {items.map((item) => (
+          {items.map((item, index) => (
             <li
-              key={item.href}
+              key={index}
               className='text-center transition-colors duration-200 hover:bg-gray-100'
               role='none'
             >

--- a/components/custom-dropdown.tsx
+++ b/components/custom-dropdown.tsx
@@ -2,7 +2,7 @@
 
 import { ChevronDownIcon } from 'lucide-react';
 import Link from 'next/link';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useId, useRef, useState } from 'react';
 
 interface DropdownItem {
   label: string;
@@ -12,20 +12,37 @@ interface DropdownItem {
 interface CustomDropdownProps {
   label: string;
   items: DropdownItem[];
+  href?: string;
 }
 
-const CustomDropdown: React.FC<CustomDropdownProps> = ({ label, items }) => {
+const CustomDropdown: React.FC<CustomDropdownProps> = ({
+  label,
+  items,
+  href,
+}) => {
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const menuRef = useRef<HTMLUListElement>(null);
+  const toggleRef = useRef<HTMLButtonElement>(null);
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const isClickOpenRef = useRef(false);
+  const menuId = useId();
 
-  const handleMouseLeave = () => {
+  const handlePointerLeave = (event: React.PointerEvent) => {
+    if (event.pointerType !== 'mouse') return;
+
     timeoutRef.current = setTimeout(() => {
-      setIsOpen(false);
+      if (
+        !isClickOpenRef.current &&
+        !dropdownRef.current?.contains(document.activeElement)
+      )
+        setIsOpen(false);
     }, 100);
   };
 
-  const handleMouseEnter = () => {
+  const handlePointerEnter = (event: React.PointerEvent) => {
+    if (event.pointerType !== 'mouse') return;
+
     if (timeoutRef.current) {
       clearTimeout(timeoutRef.current);
     }
@@ -33,11 +50,67 @@ const CustomDropdown: React.FC<CustomDropdownProps> = ({ label, items }) => {
   };
 
   const handleClick = () => {
-    setIsOpen(!isOpen);
+    // why: click pins an otherwise transient hover/focus menu so touch users
+    // and pointer users moving toward the menu get the same stable control.
+    isClickOpenRef.current = !isClickOpenRef.current;
+    setIsOpen(isClickOpenRef.current);
+  };
+
+  const handleFocus = () => {
+    setIsOpen(true);
+  };
+
+  const handleBlur = () => {
+    window.setTimeout(() => {
+      if (!dropdownRef.current?.contains(document.activeElement)) {
+        isClickOpenRef.current = false;
+        setIsOpen(false);
+      }
+    }, 0);
+  };
+
+  const handleToggleKeyDown = (event: React.KeyboardEvent) => {
+    if (event.key !== 'ArrowDown') return;
+
+    event.preventDefault();
+    setIsOpen(true);
+    window.requestAnimationFrame(() => {
+      menuRef.current?.querySelector<HTMLAnchorElement>('a')?.focus();
+    });
+  };
+
+  const handleMenuKeyDown = (event: React.KeyboardEvent<HTMLUListElement>) => {
+    const items = Array.from(
+      menuRef.current?.querySelectorAll<HTMLAnchorElement>('a') ?? [],
+    );
+    const currentIndex = items.indexOf(
+      document.activeElement as HTMLAnchorElement,
+    );
+
+    if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+      event.preventDefault();
+      const direction = event.key === 'ArrowDown' ? 1 : -1;
+      items
+        .at((currentIndex + direction + items.length) % items.length)
+        ?.focus();
+    } else if (event.key === 'Home' || event.key === 'End') {
+      event.preventDefault();
+      items.at(event.key === 'Home' ? 0 : -1)?.focus();
+    }
   };
 
   useEffect(() => {
+    const closeOnOutsidePointerDown = (event: PointerEvent) => {
+      if (!dropdownRef.current?.contains(event.target as Node)) {
+        isClickOpenRef.current = false;
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener('pointerdown', closeOnOutsidePointerDown);
+
     return () => {
+      document.removeEventListener('pointerdown', closeOnOutsidePointerDown);
       if (timeoutRef.current) {
         clearTimeout(timeoutRef.current);
       }
@@ -48,40 +121,102 @@ const CustomDropdown: React.FC<CustomDropdownProps> = ({ label, items }) => {
     <div
       className='relative'
       ref={dropdownRef}
-      onMouseEnter={handleMouseEnter}
-      onMouseLeave={handleMouseLeave}
+      onPointerEnter={handlePointerEnter}
+      onPointerLeave={handlePointerLeave}
+      onFocus={handleFocus}
+      onBlur={handleBlur}
+      onKeyDown={(event) => {
+        if (event.key === 'Escape') {
+          isClickOpenRef.current = false;
+          toggleRef.current?.focus();
+          setIsOpen(false);
+        }
+      }}
     >
-      <button
-        className='flex h-10 items-center gap-1 px-4 py-2 text-sm'
-        onClick={handleClick}
-      >
-        {label}
-        <ChevronDownIcon
-          className={`h-4 w-4 transition-transform duration-300 ${isOpen ? `rotate-180` : ''}`}
-        />
-      </button>
+      {href ? (
+        <div className='flex h-10 items-center'>
+          <Link
+            href={href}
+            className='hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground px-4 py-2 text-sm focus:outline-none'
+            onClick={() => {
+              isClickOpenRef.current = false;
+              setIsOpen(false);
+            }}
+          >
+            {label}
+          </Link>
+          <button
+            ref={toggleRef}
+            type='button'
+            className='hover:bg-accent focus:bg-accent h-full px-2 focus:outline-none'
+            onClick={handleClick}
+            onKeyDown={handleToggleKeyDown}
+            aria-controls={menuId}
+            aria-expanded={isOpen}
+            aria-haspopup='menu'
+            aria-label={`Toggle ${label} menu`}
+          >
+            <ChevronDownIcon
+              className={`h-4 w-4 transition-transform duration-300 ${isOpen ? `rotate-180` : ''}`}
+              aria-hidden='true'
+            />
+          </button>
+        </div>
+      ) : (
+        <button
+          ref={toggleRef}
+          type='button'
+          className='flex h-10 items-center gap-1 px-4 py-2 text-sm'
+          onClick={handleClick}
+          onKeyDown={handleToggleKeyDown}
+          aria-controls={menuId}
+          aria-expanded={isOpen}
+          aria-haspopup='menu'
+          aria-label={`Toggle ${label} menu`}
+        >
+          {label}
+          <ChevronDownIcon
+            className={`h-4 w-4 transition-transform duration-300 ${isOpen ? `rotate-180` : ''}`}
+            aria-hidden='true'
+          />
+        </button>
+      )}
 
       {isOpen && <div className='absolute top-full left-0 z-9999 h-6 w-full' />}
 
       <div
+        aria-hidden={!isOpen}
         className={`fixed top-[calc(100%+4px)] left-1/2 z-9999 w-40 origin-top -translate-x-1/2 transform overflow-hidden rounded-md bg-white shadow-lg transition-all duration-300 md:absolute ${
           isOpen
             ? 'scale-y-100 opacity-100'
             : 'pointer-events-none scale-y-0 opacity-0'
         }`}
-        onMouseEnter={handleMouseEnter}
-        onMouseLeave={handleMouseLeave}
+        onPointerEnter={handlePointerEnter}
+        onPointerLeave={handlePointerLeave}
         onClick={(e) => e.stopPropagation()}
       >
-        <ul className='py-1'>
-          {items.map((item, index) => (
+        <ul
+          id={menuId}
+          ref={menuRef}
+          className='py-1'
+          role='menu'
+          onKeyDown={handleMenuKeyDown}
+        >
+          {items.map((item) => (
             <li
-              key={index}
+              key={item.href}
               className='text-center transition-colors duration-200 hover:bg-gray-100'
+              role='none'
             >
               <Link
                 href={item.href}
                 className='block w-full px-4 py-2 text-sm text-gray-700'
+                role='menuitem'
+                tabIndex={isOpen ? undefined : -1}
+                onClick={() => {
+                  isClickOpenRef.current = false;
+                  setIsOpen(false);
+                }}
               >
                 {item.label}
               </Link>

--- a/components/custom-dropdown.tsx
+++ b/components/custom-dropdown.tsx
@@ -210,6 +210,12 @@ const CustomDropdown: React.FC<CustomDropdownProps> = ({
             >
               <Link
                 href={item.href}
+                target={item.href.startsWith('http') ? '_blank' : undefined}
+                rel={
+                  item.href.startsWith('http')
+                    ? 'noopener noreferrer'
+                    : undefined
+                }
                 className='block w-full px-4 py-2 text-sm text-gray-700'
                 role='menuitem'
                 tabIndex={isOpen ? undefined : -1}

--- a/components/custom-dropdown.tsx
+++ b/components/custom-dropdown.tsx
@@ -25,10 +25,12 @@ const CustomDropdown: React.FC<CustomDropdownProps> = ({
   const menuRef = useRef<HTMLUListElement>(null);
   const toggleRef = useRef<HTMLButtonElement>(null);
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+  // why: hover/focus visibility is transient, while a click pins the menu open.
   const isClickOpenRef = useRef(false);
   const menuId = useId();
 
   const handlePointerLeave = (event: React.PointerEvent) => {
+    // why: touch and pen pointers should use the stable click interaction.
     if (event.pointerType !== 'mouse') return;
 
     timeoutRef.current = setTimeout(() => {
@@ -50,8 +52,6 @@ const CustomDropdown: React.FC<CustomDropdownProps> = ({
   };
 
   const handleClick = () => {
-    // why: click pins an otherwise transient hover/focus menu so touch users
-    // and pointer users moving toward the menu get the same stable control.
     isClickOpenRef.current = !isClickOpenRef.current;
     setIsOpen(isClickOpenRef.current);
   };
@@ -61,6 +61,7 @@ const CustomDropdown: React.FC<CustomDropdownProps> = ({
   };
 
   const handleBlur = () => {
+    // why: wait for the browser to move focus before deciding it left the menu.
     window.setTimeout(() => {
       if (!dropdownRef.current?.contains(document.activeElement)) {
         isClickOpenRef.current = false;
@@ -74,6 +75,7 @@ const CustomDropdown: React.FC<CustomDropdownProps> = ({
 
     event.preventDefault();
     setIsOpen(true);
+    // why: the menu must render before its first link can receive focus.
     window.requestAnimationFrame(() => {
       menuRef.current?.querySelector<HTMLAnchorElement>('a')?.focus();
     });
@@ -182,8 +184,10 @@ const CustomDropdown: React.FC<CustomDropdownProps> = ({
         </button>
       )}
 
+      {/* why: bridge the visual gap so moving a mouse into the menu does not close it. */}
       {isOpen && <div className='absolute top-full left-0 z-9999 h-6 w-full' />}
 
+      {/* why: keep the menu mounted for its close animation, but make closed links inert. */}
       <div
         aria-hidden={!isOpen}
         className={`fixed top-[calc(100%+4px)] left-1/2 z-9999 w-40 origin-top -translate-x-1/2 transform overflow-hidden rounded-md bg-white shadow-lg transition-all duration-300 md:absolute ${

--- a/components/custom-dropdown.tsx
+++ b/components/custom-dropdown.tsx
@@ -33,6 +33,8 @@ const CustomDropdown: React.FC<CustomDropdownProps> = ({
     // why: touch and pen pointers should use the stable click interaction.
     if (event.pointerType !== 'mouse') return;
 
+    // why: a short grace period lets the pointer cross the visual gap to the
+    // menu without closing it mid-movement and causing a flicker.
     timeoutRef.current = setTimeout(() => {
       if (
         !isClickOpenRef.current &&
@@ -57,11 +59,14 @@ const CustomDropdown: React.FC<CustomDropdownProps> = ({
   };
 
   const handleFocus = () => {
+    // why: keyboard users who Tab into the control need the same menu reveal
+    // that mouse users get from hovering.
     setIsOpen(true);
   };
 
   const handleBlur = () => {
-    // why: wait for the browser to move focus before deciding it left the menu.
+    // why: blur fires before focus settles on the next element, so checking
+    // immediately would close the menu while the user Tabs into one of its links.
     window.setTimeout(() => {
       if (!dropdownRef.current?.contains(document.activeElement)) {
         isClickOpenRef.current = false;
@@ -70,18 +75,22 @@ const CustomDropdown: React.FC<CustomDropdownProps> = ({
     }, 0);
   };
 
-  const handleToggleKeyDown = (event: React.KeyboardEvent) => {
+  const handleTriggerKeyDown = (event: React.KeyboardEvent) => {
+    // why: ArrowDown is the standard shortcut for entering an attached menu;
+    // handling keydown lets us prevent page scrolling before it occurs.
     if (event.key !== 'ArrowDown') return;
 
     event.preventDefault();
     setIsOpen(true);
-    // why: the menu must render before its first link can receive focus.
+    // why: let React commit the open state before moving keyboard focus into the menu.
     window.requestAnimationFrame(() => {
       menuRef.current?.querySelector<HTMLAnchorElement>('a')?.focus();
     });
   };
 
   const handleMenuKeyDown = (event: React.KeyboardEvent<HTMLUListElement>) => {
+    // why: menu-style arrow navigation moves focus between choices without
+    // making keyboard users Tab through the rest of the page.
     const items = Array.from(
       menuRef.current?.querySelectorAll<HTMLAnchorElement>('a') ?? [],
     );
@@ -135,11 +144,16 @@ const CustomDropdown: React.FC<CustomDropdownProps> = ({
         }
       }}
     >
+      {/* why: both trigger variants must expose the controlled menu and its open state to screen readers. */}
       {href ? (
         <div className='flex h-10 items-center'>
           <Link
             href={href}
             className='hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground px-4 py-2 text-sm focus:outline-none'
+            onKeyDown={handleTriggerKeyDown}
+            aria-controls={menuId}
+            aria-expanded={isOpen}
+            aria-haspopup='menu'
             onClick={() => {
               isClickOpenRef.current = false;
               setIsOpen(false);
@@ -147,12 +161,13 @@ const CustomDropdown: React.FC<CustomDropdownProps> = ({
           >
             {label}
           </Link>
+          {/* why: screen readers need to distinguish this menu toggle from the adjacent page link. */}
           <button
             ref={toggleRef}
             type='button'
             className='hover:bg-accent focus:bg-accent h-full px-2 focus:outline-none'
             onClick={handleClick}
-            onKeyDown={handleToggleKeyDown}
+            onKeyDown={handleTriggerKeyDown}
             aria-controls={menuId}
             aria-expanded={isOpen}
             aria-haspopup='menu'
@@ -170,7 +185,7 @@ const CustomDropdown: React.FC<CustomDropdownProps> = ({
           type='button'
           className='flex h-10 items-center gap-1 px-4 py-2 text-sm'
           onClick={handleClick}
-          onKeyDown={handleToggleKeyDown}
+          onKeyDown={handleTriggerKeyDown}
           aria-controls={menuId}
           aria-expanded={isOpen}
           aria-haspopup='menu'
@@ -188,6 +203,7 @@ const CustomDropdown: React.FC<CustomDropdownProps> = ({
       {isOpen && <div className='absolute top-full left-0 z-9999 h-6 w-full' />}
 
       {/* why: keep the menu mounted for its close animation, but make closed links inert. */}
+      {/* why: assistive technology also needs an explicit signal while those mounted contents are unavailable. */}
       <div
         aria-hidden={!isOpen}
         className={`fixed top-[calc(100%+4px)] left-1/2 z-9999 w-40 origin-top -translate-x-1/2 transform overflow-hidden rounded-md bg-white shadow-lg transition-all duration-300 md:absolute ${
@@ -199,6 +215,7 @@ const CustomDropdown: React.FC<CustomDropdownProps> = ({
         onPointerLeave={handlePointerLeave}
         onClick={(e) => e.stopPropagation()}
       >
+        {/* why: menu semantics announce that arrow keys move between these choices. */}
         <ul
           id={menuId}
           ref={menuRef}

--- a/lib/archive.ts
+++ b/lib/archive.ts
@@ -20,11 +20,6 @@ export interface ArchiveDefinition {
   years: readonly ArchiveYear[];
 }
 
-export interface ArchiveDropdownItem {
-  label: string;
-  href: string;
-}
-
 export const newsletterArchive = {
   name: 'Newsletter Archive',
   href: '/newsletter',
@@ -110,19 +105,3 @@ export const wikiArchive = {
 
 export const anchorForArchiveYear = (year: string) =>
   year.toLowerCase().replaceAll(/[^a-z0-9]+/g, '-');
-
-export function getArchiveDropdownItems(
-  archive: ArchiveDefinition,
-): ArchiveDropdownItem[] {
-  return archive.years.map((entry) => {
-    if (entry.editions?.length === 1) {
-      return { label: entry.year, href: entry.editions[0].href };
-    }
-
-    // why: forthcoming and multi-edition years need the index because no single destination is canonical.
-    return {
-      label: entry.year,
-      href: `${archive.href}#${anchorForArchiveYear(entry.year)}`,
-    };
-  });
-}

--- a/lib/archive.ts
+++ b/lib/archive.ts
@@ -1,0 +1,124 @@
+export interface ArchiveEdition {
+  label: string;
+  href: string;
+}
+
+export type ArchiveYear =
+  | {
+      year: string;
+      editions?: undefined;
+    }
+  | {
+      year: string;
+      editions: readonly [ArchiveEdition, ...ArchiveEdition[]];
+    };
+
+export interface ArchiveDefinition {
+  name: string;
+  href: string;
+  description: string;
+  years: readonly ArchiveYear[];
+}
+
+export interface ArchiveDropdownItem {
+  label: string;
+  href: string;
+}
+
+export const newsletterArchive = {
+  name: 'Newsletter Archive',
+  href: '/newsletter',
+  description:
+    'Browse past NUS College Club newsletters and keep up with the stories, updates, and moments that shaped Student Life.',
+  years: [
+    // why: omitting editions is the single forthcoming state used by every archive surface.
+    { year: 'AY26/27' },
+    {
+      year: 'AY25/26',
+      editions: [
+        {
+          label: 'Issue 1 - Semester 1',
+          href: 'https://ogmmddvrmieazwmy.public.blob.vercel-storage.com/newsletters/ay25-26/semester-1.pdf',
+        },
+        {
+          label: 'Issue 2 - Semester 2',
+          href: 'https://ogmmddvrmieazwmy.public.blob.vercel-storage.com/newsletters/ay25-26/semester-2.pdf',
+        },
+      ],
+    },
+    {
+      year: 'AY24/25',
+      editions: [
+        {
+          label: 'Issue 1 - Semester 1',
+          href: 'https://ogmmddvrmieazwmy.public.blob.vercel-storage.com/newsletters/ay24-25/semester-1.pdf',
+        },
+      ],
+    },
+    {
+      year: 'AY22/23',
+      editions: [
+        {
+          label: 'The NUSC Minute',
+          href: 'https://ogmmddvrmieazwmy.public.blob.vercel-storage.com/newsletters/ay22-23/the-nusc-minute.pdf',
+        },
+      ],
+    },
+  ],
+} satisfies ArchiveDefinition;
+
+export const wikiArchive = {
+  name: 'Wiki Archive',
+  href: '/wiki',
+  description:
+    'Explore the NUS College Club wiki archives for practical guides, community knowledge, and resources collected by students.',
+  years: [
+    { year: 'AY25/26' },
+    {
+      year: 'AY24/25',
+      editions: [
+        {
+          label: 'VIEW WIKI',
+          href: 'https://sites.google.com/view/nusc-wiki-2425/home',
+        },
+      ],
+    },
+    {
+      year: 'AY23/24',
+      editions: [
+        {
+          label: 'VIEW WIKI',
+          href: 'https://nusc-wiki.gitbook.io/nusc-wiki-23-24/',
+        },
+      ],
+    },
+    {
+      year: 'AY22/23',
+      editions: [
+        {
+          label: 'VIEW WIKI',
+          href: 'https://nusc-wiki.gitbook.io/nusc-wiki-22/',
+        },
+      ],
+    },
+  ],
+} satisfies ArchiveDefinition;
+
+export const anchorForArchiveYear = (year: string) =>
+  year.toLowerCase().replaceAll(/[^a-z0-9]+/g, '-');
+
+export function getArchiveDropdownItems(
+  archive: ArchiveDefinition,
+): ArchiveDropdownItem[] {
+  return archive.years.map((entry) => {
+    if (entry.editions?.length === 1) {
+      return { label: entry.year, href: entry.editions[0].href };
+    }
+
+    // why: forthcoming and multi-edition years need the index because no single destination is canonical.
+    return {
+      label: entry.year,
+      href: `${archive.href}#${anchorForArchiveYear(entry.year)}`,
+    };
+  });
+}

--- a/lib/archive.ts
+++ b/lib/archive.ts
@@ -53,6 +53,10 @@ export const newsletterArchive = {
           label: 'Issue 1 - Semester 1',
           href: 'https://ogmmddvrmieazwmy.public.blob.vercel-storage.com/newsletters/ay24-25/semester-1.pdf',
         },
+        {
+          label: 'Issue 2 - Semester 2',
+          href: 'https://ogmmddvrmieazwmy.public.blob.vercel-storage.com/newsletters/ay24-25/semester-2.pdf',
+        },
       ],
     },
     {


### PR DESCRIPTION
Closes #29

## Summary
- add separate Newsletter and Wiki archive pages with verified editions and clear forthcoming states
- replace the mislabeled external Newsletter link with internal archive navigation
- support desktop hover/keyboard menus and mobile year accordions
- host PDFs in the team-owned `nusc-website-blob` Vercel Blob store

<img width="432" height="238" alt="image" src="https://github.com/user-attachments/assets/dc55d50f-0ee0-4126-8729-117021b17921" />
<img width="1285" height="651" alt="image" src="https://github.com/user-attachments/assets/557e2ad5-4c0f-4c07-a9f8-3c84fa3ae624" />


## Verification
- `npm run build` - passes, including compilation, TypeScript, and static generation
- `npx prettier --check app/newsletter/page.tsx` - passes
- `npx eslint app/newsletter/page.tsx` - passes; GitHub `lint` check also passes
- Blob response - HTTP 200, `application/pdf`, 58,495,962 bytes, with SHA-256 matching the supplied PDF
- browser QA - Newsletter and Wiki routes return 200; desktop hover and mobile accordions work at 1280x720 and 375x812 with no horizontal overflow
- Vercel preview deployment - passes